### PR TITLE
Fix: Bad Line Endings Parsing and NAN shown in table

### DIFF
--- a/processor/open_logs_processor.py
+++ b/processor/open_logs_processor.py
@@ -47,10 +47,12 @@ class OpenLogsProcessor(IProcessor):
                 common_path_prefix = os.path.commonpath(file_paths)
         rows = []
         for file_path in file_paths:
-            with open(file_path, 'r', errors='ignore', encoding='utf-8') as file:
+            with open(file_path, 'r', encoding='utf-8', errors='replace', newline='') as file:
                 for line in file:
-                    # Strip any line ending whitespace/newline characters
-                    line = line.rstrip()
+                    # Strip any line ending whitespace/newline characters and remove null bytes
+                    line = line.replace('\x00', '').rstrip()
+                    if not line:
+                        continue  # Skip empty lines
                     if keepSourceFileLocation == KEEP_SOURCE_FILE_LOCATION_ENUM.FULL_PATH:
                         visible_file_value = file_path
                     elif keepSourceFileLocation == KEEP_SOURCE_FILE_LOCATION_ENUM.FILE_ONLY:
@@ -65,7 +67,9 @@ class OpenLogsProcessor(IProcessor):
                         PREDEFINED_COLUMN_NAMES.MESSAGE.value: line,
                         'Original Messages': line
                     })
-        data = DataFrame(rows).reset_index(drop=True)
+        print(f"Opened {len(rows)} log lines from {len(file_paths)} files.")
+        print(rows[:5])
+        data = DataFrame(rows, dtype=str).reset_index(drop=True)
         # Optionally, return the 'File' column if requested
         result = []
         if keepSourceFileLocation != KEEP_SOURCE_FILE_LOCATION_ENUM.NONE:

--- a/processor/split_log_lines_processor.py
+++ b/processor/split_log_lines_processor.py
@@ -59,9 +59,9 @@ class SplitLogLinesProcessor(IProcessor):
             print("Error extracting groups:", e)
             return None
 
-        # Apply timestamp format if specified
-        # ex. <Year>-<Month>-<Day> <Hour>:<Minutes>:<Seconds>
-        # These tags must exist and are already processed in separate columns
+        # Convert all possible nan's to empty string
+        data = data.fillna("")
+
         if timestamp_format_arg is not None:
             timestamp_format_arg = timestamp_format_arg.strip()
         else:
@@ -73,7 +73,7 @@ class SplitLogLinesProcessor(IProcessor):
                 # Apply extraction from columns to 'Timestamp' column
                 # Insert as column 2
                 timestamp_col = data[timestamp_tags].apply(
-                    lambda row: agg_format.format(*row.values),
+                    lambda row: agg_format.format(*row.values) if all(isinstance(val, str) and val!="" for val in row.values) else "",
                     axis=1
                 )
                 data.insert(len(timestamp_tags)+1, 'Timestamp', timestamp_col)


### PR DESCRIPTION
+ Read files as binary UTF8 and decode lines to avoid bad line endings
+ Manually replace NULL bytes and other non-printable characters
+ Skip empty lines after cleaning
+ Fix regex to correctly parse lines and avoid NAN in output table